### PR TITLE
Fix: Align configmap references with karectl naming convention

### DIFF
--- a/manifests/cr8tor-operator/deployment.yaml
+++ b/manifests/cr8tor-operator/deployment.yaml
@@ -61,17 +61,17 @@ spec:
             - name: KEYCLOAK_REALM
               valueFrom:
                 configMapKeyRef:
-                  name: k8tre-realm-config
+                  name: karectl-realm-config
                   key: realm-name
             - name: KEYCLOAK_URL
               valueFrom:
                 configMapKeyRef:
-                  name: k8tre-realm-config
+                  name: karectl-realm-config
                   key: keycloak-url
             - name: KEYCLOAK_VERIFY_TLS
               valueFrom:
                 configMapKeyRef:
-                  name: k8tre-realm-config
+                  name: karectl-realm-config
                   key: keycloak-verify-tls
 
           volumeMounts:


### PR DESCRIPTION
Fixes issue where operator fails to start with: configmap 'k8tre-realm-config' not found
