### PR TITLE
Fix VDI desktop shortcut urls afwe will ter DOMAIN variable consolidation

### DIFF
--- a/manifests/cr8tor-operator/configmaps.yaml
+++ b/manifests/cr8tor-operator/configmaps.yaml
@@ -219,7 +219,7 @@ data:
             # External URL
             BACKEND_HOST=$(echo "${KARECTL_BACKEND_URL}" | sed 's|https\?://portal\.||' | sed 's|/.*||')
             ENVIRONMENT=$(echo "${BACKEND_HOST}" | cut -d. -f1)
-            DOMAIN=$(echo "${BACKEND_HOST}" | cut -d. -f2-)
+            DOMAIN="${BACKEND_HOST}"
             echo "Extracted environment and domain from portal URL"
         fi
     else
@@ -272,7 +272,7 @@ data:
     chmod +x "${DESKTOP_DIR}/firefox.desktop"
 
     if [ -n "${KARECTL_TOKEN}" ]; then
-        SSO_URL="https://portal.${ENVIRONMENT}.${DOMAIN}/auth/sso?token=${KARECTL_TOKEN}&project=${KARECTL_PROJECT}&app=jupyter"
+        SSO_URL="https://portal.${DOMAIN}/auth/sso?token=${KARECTL_TOKEN}&project=${KARECTL_PROJECT}&app=jupyter"
 
         create_desktop_shortcut \
             "JupyterHub - ${KARECTL_PROJECT^}" \


### PR DESCRIPTION
After the DOMAIN variable consolidation, VDI desktop shortcuts were constructing incorrect SSO URLs with double environment prefixes.
