### PR TITLE
Add support for custom passwords and password status tracking

### DIFF
--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -13,11 +13,15 @@ from cr8tor.services.client import ensure_realm_exists
 
 @kopf.on.create("identity.karectl.io", "v1alpha1", "user")
 @kopf.on.update("identity.karectl.io", "v1alpha1", "user")
-def user_create_update(body, spec, meta, **kwargs):
+def user_create_update(body, spec, meta, status, patch, **kwargs):
     """Operator function for creating and updating users."""
     username = spec["username"]
     ensure_realm_exists()
-    sync_keycloak_user(username, spec)
+    result = sync_keycloak_user(username, spec)
+
+    if result and "password" in result:
+        patch.status["initialPassword"] = result["password"]
+
     kopf.info(meta, reason="UserSynced", message=f"User {username} synced.")
 
 

--- a/src/cr8tor/models/identity.py
+++ b/src/cr8tor/models/identity.py
@@ -13,6 +13,9 @@ class UserSpec(CRDSpec):
     username: str = Field(..., description="Unique username for the user")
     email: str = Field(..., description="Email address of the user")
     enabled: bool = Field(default=True, description="Whether the user is enabled")
+    password: Optional[str] = Field(
+        default=None, description="User password (if not set, a temporary password will be generated)"
+    )
     groups: List[str] = Field(
         default_factory=list, description="List of groups the user belongs to"
     )


### PR DESCRIPTION
Added ability to specify custom passwords for keycloak users and exposes initial passwords (both custom and auto-generated) in the Kubernetes resource status for easy retrieval.           