### PR TITLE
Updated to use project access for users from Group CRDs

### DIFF
--- a/src/cr8tor/cli/deploy.py
+++ b/src/cr8tor/cli/deploy.py
@@ -346,14 +346,6 @@ def create_deployment(
     for requesting_agent in governance.users:
         log.info(f"\nLoaded requesting agent: {requesting_agent.username}")
 
-        # Project-scoped groups are managed via Group CRDs
-        governance_groups = [
-            {"value": group.value, "display": group.display, "type": group.type}
-            for group in (requesting_agent.groups or [])
-            if group.value
-        ]
-        log.info(f"User identity groups from governance: {[g['value'] for g in governance_groups]}")
-
         # Create UserSpec
         try:
             user_spec = User(
@@ -364,7 +356,6 @@ def create_deployment(
                 given_name=requesting_agent.given_name,
                 family_name=requesting_agent.family_name,
                 affiliation=requesting_agent.affiliation,
-                groups=governance_groups,
                 password=requesting_agent.password,
             )
             log.info(f"Created UserSpec for {user_spec.username}")

--- a/src/cr8tor/cli/deploy.py
+++ b/src/cr8tor/cli/deploy.py
@@ -346,13 +346,13 @@ def create_deployment(
     for requesting_agent in governance.users:
         log.info(f"\nLoaded requesting agent: {requesting_agent.username}")
 
-        # Derive the group for this user
-        user_project_groups = [
-            {"value": group_name, "display": group_spec.description, "type": "Manual"}
-            for group_name, group_spec in group_definitions
-            if requesting_agent.username in (group_spec.members or [])
+        # Project-scoped groups are managed via Group CRDs
+        governance_groups = [
+            {"value": group.value, "display": group.display, "type": group.type}
+            for group in (requesting_agent.groups or [])
+            if group.value
         ]
-        log.info(f"User will be added to groups: {[g['value'] for g in user_project_groups]}")
+        log.info(f"User identity groups from governance: {[g['value'] for g in governance_groups]}")
 
         # Create UserSpec
         try:
@@ -364,7 +364,7 @@ def create_deployment(
                 given_name=requesting_agent.given_name,
                 family_name=requesting_agent.family_name,
                 affiliation=requesting_agent.affiliation,
-                groups=user_project_groups,
+                groups=governance_groups,
                 password=requesting_agent.password,
             )
             log.info(f"Created UserSpec for {user_spec.username}")
@@ -372,14 +372,14 @@ def create_deployment(
             log.info(f"Failed to create UserSpec: {e}", err=True)
             raise typer.Exit(1)
 
-        # Create full User CRD
+        # Create full User CRD.
+        # project binding is managed entirely via Group CRDs, not the User CRD.
         user_crd = {
             "apiVersion": "identity.karectl.io/v1alpha1",
             "kind": "User",
             "metadata": {
                 "name": requesting_agent.username,
                 "labels": {
-                    "cr8tor.io/project-id": _sanitise_label(project_props.id or "unknown"),
                     "cr8tor.io/created-at": datetime.now().strftime("%Y%m%d"),
                 },
             },

--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -35,41 +35,31 @@ logger = logging.getLogger(__name__)
 IDENTITY_NAMESPACE = os.environ.get("IDENTITY_NAMESPACE", "keycloak")
 
 
-def get_user_projects(user_groups):
-    """Resolve all projects from a list of group memberships.
+def get_user_projects(username):
+    """ Resolve all projects the user has access to by scanning Group CRDs for membership.
 
     Args:
-        user_groups: List of group names or dicts (from User CRD spec.groups).
+        username: The username to look up across all Group CRD members lists.
     """
     api = kubernetes.client.CustomObjectsApi()
     projects = set()
 
-    for group in user_groups:
-        # Groups can be plain strings or dicts
-        if isinstance(group, dict):
-            group_name = group.get("value")
-        else:
-            group_name = group
-
-        if not group_name:
-            continue
-
-        try:
-            group_cr = api.get_namespaced_custom_object(
-                group="identity.karectl.io",
-                version="v1alpha1",
-                namespace=IDENTITY_NAMESPACE,
-                plural="groups",
-                name=group_name,
-            )
-            group_projects = group_cr.get("spec", {}).get("projects", [])
-            projects.update(group_projects)
-            logger.info(f"Group {group_name} has projects: {group_projects}")
-        except ApiException as e:
-            if e.status == 404:
-                logger.warning(f"Group {group_name} not found")
-            else:
-                logger.error(f"Failed to fetch group {group_name}: {e}")
+    try:
+        all_groups = api.list_namespaced_custom_object(
+            group="identity.karectl.io",
+            version="v1alpha1",
+            namespace=IDENTITY_NAMESPACE,
+            plural="groups",
+        )
+        for group_cr in all_groups.get("items", []):
+            members = group_cr.get("spec", {}).get("members", [])
+            if username in members:
+                group_name = group_cr.get("metadata", {}).get("name", "")
+                group_projects = group_cr.get("spec", {}).get("projects", [])
+                projects.update(group_projects)
+                logger.info(f"Group {group_name} has {username} as member, projects: {group_projects}")
+    except ApiException as e:
+        logger.error(f"Failed to list groups for project resolution of {username}: {e}")
 
     return projects
 
@@ -209,8 +199,6 @@ def user_create_update(body, spec, meta, status, patch, **kwargs):
         Provision notebook PVCs for the projects the user has access to.
     """
     username = spec["username"]
-    user_groups = spec.get("groups", [])
-
     ensure_realm_exists()
     result = sync_keycloak_user(username, spec)
 
@@ -219,41 +207,38 @@ def user_create_update(body, spec, meta, status, patch, **kwargs):
 
     kopf.info(meta, reason="UserSynced", message=f"User {username} synced.")
 
-    # Provision notebook PVCs for user's projects
-    if user_groups:
-        projects = get_user_projects(user_groups)
+    # Provision notebook PVCs for user's projects.
+    projects = get_user_projects(username)
 
-        if projects:
-            logger.info(f"Provisioning notebook storage for {username} in {len(projects)} projects: {projects}")
-            pvc_results = ensure_user_notebook_pvc(username, projects)
+    if projects:
+        logger.info(f"Provisioning notebook storage for {username} in {len(projects)} projects: {projects}")
+        pvc_results = ensure_user_notebook_pvc(username, projects)
 
-            # Track storage and status
-            provisioned = [pvc for pvc, reason in pvc_results.items() if reason.get("status") in ("created", "exists")]
-            skipped = [pvc for pvc, reason in pvc_results.items() if reason.get("status") == "skipped"]
-            errors = [pvc for pvc, reason in pvc_results.items() if reason.get("status") == "error"]
+        # Track storage and status
+        provisioned = [pvc for pvc, reason in pvc_results.items() if reason.get("status") in ("created", "exists")]
+        skipped = [pvc for pvc, reason in pvc_results.items() if reason.get("status") == "skipped"]
+        errors = [pvc for pvc, reason in pvc_results.items() if reason.get("status") == "error"]
 
-            patch.status["notebookStorage"] = {
-                "provisioned": provisioned,
-                "skipped": skipped,
-                "errors": errors,
-            }
+        patch.status["notebookStorage"] = {
+            "provisioned": provisioned,
+            "skipped": skipped,
+            "errors": errors,
+        }
 
-            if provisioned:
-                kopf.info(
-                    meta,
-                    reason="StorageProvisioned",
-                    message=f"Notebook storage provisioned for {username} in projects: {', '.join(provisioned)}",
-                )
-            if errors:
-                kopf.warn(
-                    meta,
-                    reason="StorageError",
-                    message=f"Failed to provision storage in projects: {', '.join(errors)}",
-                )
-        else:
-            logger.info(f"User {username} has groups but no projects configured")
+        if provisioned:
+            kopf.info(
+                meta,
+                reason="StorageProvisioned",
+                message=f"Notebook storage provisioned for {username} in projects: {', '.join(provisioned)}",
+            )
+        if errors:
+            kopf.warn(
+                meta,
+                reason="StorageError",
+                message=f"Failed to provision storage in projects: {', '.join(errors)}",
+            )
     else:
-        logger.info(f"User {username} has no groups, skipping storage provisioning")
+        logger.info(f"No project group memberships found for {username}, skipping storage provisioning")
 
 
 @kopf.on.delete("identity.karectl.io", "v1alpha1", "user")
@@ -263,18 +248,16 @@ def user_delete(body, spec, meta, **kwargs):
         PVCs are cleaned up when Project is deleted (namespace cascading deletion)
     """
     username = spec["username"]
-    user_groups = spec.get("groups", [])
 
     delete_keycloak_user(username)
 
     # Update which PVCs will be retained
-    if user_groups:
-        projects = get_user_projects(user_groups)
-        if projects:
-            logger.info(
-                f"User {username} deleted. Notebook PVCs retained in projects: {projects}. "
-                "PVCs will be cleaned up when project is deleted."
-            )
+    projects = get_user_projects(username)
+    if projects:
+        logger.info(
+            f"User {username} deleted. Notebook PVCs retained in projects: {projects}. "
+            "PVCs will be cleaned up when project is deleted."
+        )
 
     kopf.info(meta, reason="UserDeleted", message=f"User {username} deleted. Notebook PVCs retained.")
 

--- a/src/cr8tor/services/group_manager.py
+++ b/src/cr8tor/services/group_manager.py
@@ -21,6 +21,23 @@ def sync_keycloak_group(groupname, spec):
             {"name": groupname, "attributes": attributes}
         )
 
+    desired_usernames = set(members)
+
+    # Remove users no longer in spec (project access revocation).
+    try:
+        current_kc_members = keycloak_client.get_group_members(group_id)
+    except Exception as e:
+        print(f"[WARN] Could not fetch current members of {groupname}: {e}")
+        current_kc_members = []
+
+    for kc_member in current_kc_members:
+        if kc_member.get("username") not in desired_usernames:
+            try:
+                keycloak_client.group_user_remove(kc_member["id"], group_id)
+                print(f"[INFO] Removed {kc_member.get('username')} from {groupname} (no longer in spec)")
+            except Exception as e:
+                print(f"[WARN] Could not remove {kc_member.get('username')} from {groupname}: {e}")
+
     for username in members:
         try:
             user_id = keycloak_client.get_user_id(username)

--- a/src/cr8tor/services/group_manager.py
+++ b/src/cr8tor/services/group_manager.py
@@ -1,4 +1,9 @@
+import logging
+
+from keycloak.exceptions import KeycloakGetError, KeycloakDeleteError, KeycloakPutError
 from .client import get_client
+
+logger = logging.getLogger(__name__)
 
 
 def sync_keycloak_group(groupname, spec):
@@ -26,26 +31,29 @@ def sync_keycloak_group(groupname, spec):
     # Remove users no longer in spec (project access revocation).
     try:
         current_kc_members = keycloak_client.get_group_members(group_id)
-    except Exception as e:
-        print(f"[WARN] Could not fetch current members of {groupname}: {e}")
+    except KeycloakGetError as e:
+        logger.warning(f"Could not fetch current members of {groupname}: {e}")
         current_kc_members = []
 
     for kc_member in current_kc_members:
         if kc_member.get("username") not in desired_usernames:
+            member_id = kc_member["id"]
             try:
-                keycloak_client.group_user_remove(kc_member["id"], group_id)
-                print(f"[INFO] Removed {kc_member.get('username')} from {groupname} (no longer in spec)")
-            except Exception as e:
-                print(f"[WARN] Could not remove {kc_member.get('username')} from {groupname}: {e}")
+                keycloak_client.group_user_remove(member_id, group_id)
+                logger.info(f"Removed {kc_member.get('username')} (user_id={member_id}) from {groupname} (group_id={group_id})")
+            except KeycloakDeleteError as e:
+                logger.warning(f"Could not remove {kc_member.get('username')} (user_id={member_id}) from {groupname} (group_id={group_id}): {e}")
 
     for username in members:
         try:
             user_id = keycloak_client.get_user_id(username)
             keycloak_client.group_user_add(user_id, group_id)
-        except Exception as e:
-            print(f"Could not add {username} to {groupname}: {e}")
+        except KeycloakGetError as e:
+            logger.warning(f"Could not resolve user {username} for group {groupname} (group_id={group_id}): {e}")
+        except KeycloakPutError as e:
+            logger.warning(f"Could not add {username} to {groupname} (group_id={group_id}): {e}")
 
-    print(f"Synced group {groupname}")
+    logger.info(f"Synced group {groupname}")
 
 
 def delete_keycloak_group(groupname):
@@ -56,6 +64,6 @@ def delete_keycloak_group(groupname):
 
     if group:
         keycloak_client.delete_group(group[0]["id"])
-        print(f"Deleted group {groupname}")
+        logger.info(f"Deleted group {groupname}")
     else:
-        print(f"Group {groupname} not found")
+        logger.warning(f"Group {groupname} not found")

--- a/src/cr8tor/services/user_manager.py
+++ b/src/cr8tor/services/user_manager.py
@@ -8,7 +8,6 @@ def sync_keycloak_user(username, spec):
     keycloak_client = get_client()
     email = spec.get("email")
     enabled = spec.get("enabled", True)
-    groups = spec.get("groups", [])
     password = spec.get("password")
     first_name = spec.get("given_name", "")
     last_name = spec.get("family_name", "")
@@ -45,19 +44,6 @@ def sync_keycloak_user(username, spec):
 
     # Always get the actual user_id (in case it was just created)
     user_id = keycloak_client.get_user_id(username)
-
-    for group_entry in groups:
-        # Groups can be plain strings or dicts with a 'value' key
-        groupname = group_entry.get("value") if isinstance(group_entry, dict) else group_entry
-        if not groupname:
-            continue
-        group = [
-            grp for grp in keycloak_client.get_groups() if grp["name"] == groupname
-        ]
-        if group:
-            keycloak_client.group_user_add(user_id, group[0]["id"])
-        else:
-            print(f"[WARN] Group {groupname} not found")
 
     # Set a temp password if the user was just created
     if user_created:

--- a/src/cr8tor/services/user_manager.py
+++ b/src/cr8tor/services/user_manager.py
@@ -46,9 +46,6 @@ def sync_keycloak_user(username, spec):
     # Always get the actual user_id (in case it was just created)
     user_id = keycloak_client.get_user_id(username)
 
-    for group in keycloak_client.get_user_groups(user_id):
-        keycloak_client.group_user_remove(user_id, group["id"])
-
     for group_entry in groups:
         # Groups can be plain strings or dicts with a 'value' key
         groupname = group_entry.get("value") if isinstance(group_entry, dict) else group_entry


### PR DESCRIPTION
Issue 
- Two projects sharing a username would overwrite each other's User CRD from cr8tor-projects
- Made stripping group memberships and hiding projects in the portal.

Fix
- User CRDs no longer embed project-scoped groups or cr8tor.io/project-id label
- get_user_projects now scans group CRDs instead of reading spec.groups from the user CRD
- Group crds are the single source of truth for project access.
