### PR TITLE
feat: Use k8s CRD UIDs for pvc naming to prevent collision on normalised names

### DIFF
--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -135,6 +135,7 @@ def ensure_user_notebook_pvc(username, projects, user_uid):
         user_uid: k8s metadata.uid of the User CRD
     """
     results = {}
+    project_uid_cache = {}
 
     for project_name in projects:
         try:
@@ -149,7 +150,16 @@ def ensure_user_notebook_pvc(username, projects, user_uid):
                 results[project_name] = {"status": "skipped", "reason": "no_storage_config"}
                 continue
 
-            project_uid = get_project_uid(project_name)
+            if project_name not in project_uid_cache:
+                try:
+                    project_uid_cache[project_name] = get_project_uid(project_name)
+                except ApiException as e:
+                    if e.status == 404:
+                        logger.warning(f"Project CRD {project_name} not found, skipping PVC for {username}")
+                        results[project_name] = {"status": "skipped", "reason": "project_crd_not_found"}
+                        continue
+                    raise
+            project_uid = project_uid_cache[project_name]
             pvc_name = get_pvc_name("notebook", user_uid, project_uid)
             labels = {
                 "karectl.io/user": username,
@@ -171,12 +181,8 @@ def ensure_user_notebook_pvc(username, projects, user_uid):
             results[project_name] = result
 
         except ApiException as e:
-            if e.status == 404:
-                logger.warning(f"Project namespace {project_name} not found, skipping PVC for {username}")
-                results[project_name] = {"status": "skipped", "reason": "namespace_not_found"}
-            else:
-                logger.error(f"Failed to create notebook PVC for {username} in {project_name}: {e}")
-                results[project_name] = {"status": "error", "error": str(e)}
+            logger.error(f"Failed to create notebook PVC for {username} in {project_name}: {e}")
+            results[project_name] = {"status": "error", "error": str(e)}
         except Exception as e:
             logger.error(f"Failed to create notebook PVC for {username} in {project_name}: {e}")
             results[project_name] = {"status": "error", "error": str(e)}

--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -227,6 +227,7 @@ def cleanup_user_notebook_pvcs(username, projects):
 
 @kopf.on.create("identity.karectl.io", "v1alpha1", "user")
 @kopf.on.update("identity.karectl.io", "v1alpha1", "user")
+@kopf.on.resume("identity.karectl.io", "v1alpha1", "user")
 def user_create_update(body, spec, meta, status, patch, **kwargs):
     """ Operator function for creating and updating users.
         Provision notebook PVCs for the projects the user has access to.

--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -26,6 +26,7 @@ from cr8tor.services.storage_manager import (
     ensure_workspace_pvc,
     delete_workspace_pvc,
     get_pvc_name,
+    get_project_uid,
     resolve_notebook_storage_config,
 )
 
@@ -33,6 +34,23 @@ logger = logging.getLogger(__name__)
 
 # Namespace where User and Group CRDs are stored
 IDENTITY_NAMESPACE = os.environ.get("IDENTITY_NAMESPACE", "keycloak")
+
+
+def _get_user_uid(username):
+    """Get the metadata.uid of a User CRD.
+
+    Args:
+        username: username (CRD resource name)
+    """
+    api = kubernetes.client.CustomObjectsApi()
+    user = api.get_namespaced_custom_object(
+        group="identity.karectl.io",
+        version="v1alpha1",
+        plural="users",
+        namespace=IDENTITY_NAMESPACE,
+        name=username,
+    )
+    return user["metadata"]["uid"]
 
 
 def get_user_projects(username):
@@ -108,12 +126,13 @@ def get_group_members(group_name):
     return members
 
 
-def ensure_user_notebook_pvc(username, projects):
+def ensure_user_notebook_pvc(username, projects, user_uid):
     """Ensure notebook PVCs exist for a user in the projects.
 
     Args:
         username: username
         projects: Set/list of project names
+        user_uid: k8s metadata.uid of the User CRD
     """
     results = {}
 
@@ -130,8 +149,8 @@ def ensure_user_notebook_pvc(username, projects):
                 results[project_name] = {"status": "skipped", "reason": "no_storage_config"}
                 continue
 
-            pvc_name = get_pvc_name("notebook", username, project_name)
-            # Tracker labels for PVC
+            project_uid = get_project_uid(project_name)
+            pvc_name = get_pvc_name("notebook", user_uid, project_uid)
             labels = {
                 "karectl.io/user": username,
                 "karectl.io/project": project_name,
@@ -173,13 +192,27 @@ def cleanup_user_notebook_pvcs(username, projects):
         projects: Set/list of project names to remove PVCs
     """
     results = {}
+    core_api = kubernetes.client.CoreV1Api()
 
     for project_name in projects:
         try:
             namespace = get_proj_namespace(project_name)
-            pvc_name = get_pvc_name("notebook", username, project_name)
-            result = delete_workspace_pvc(namespace, pvc_name)
-            logger.info(f"Notebook PVC cleanup for {username} in {project_name}: {result['status']}")
+            pvcs = core_api.list_namespaced_persistent_volume_claim(
+                namespace=namespace,
+                label_selector=(
+                    f"karectl.io/user={username},"
+                    f"karectl.io/project={project_name},"
+                    f"karectl.io/workspace-type=notebook"
+                ),
+            )
+            if not pvcs.items:
+                logger.info(f"No notebook PVC found for {username} in {project_name}")
+                results[project_name] = {"status": "not_found"}
+                continue
+
+            for pvc in pvcs.items:
+                result = delete_workspace_pvc(namespace, pvc.metadata.name)
+                logger.info(f"Notebook PVC cleanup for {username} in {project_name}: {result['status']}")
             results[project_name] = result
 
         except Exception as e:
@@ -208,11 +241,14 @@ def user_create_update(body, spec, meta, status, patch, **kwargs):
     kopf.info(meta, reason="UserSynced", message=f"User {username} synced.")
 
     # Provision notebook PVCs for user's projects.
+    # meta["uid"] is the User CRD's UID used to uniquely identify
+    # the user across project group membership changes.
+    user_uid = meta["uid"]
     projects = get_user_projects(username)
 
     if projects:
         logger.info(f"Provisioning notebook storage for {username} in {len(projects)} projects: {projects}")
-        pvc_results = ensure_user_notebook_pvc(username, projects)
+        pvc_results = ensure_user_notebook_pvc(username, projects, user_uid)
 
         # Track storage and status
         provisioned = [pvc for pvc, reason in pvc_results.items() if reason.get("status") in ("created", "exists")]
@@ -285,7 +321,15 @@ def group_create_update(body, spec, meta, patch, **kwargs):
 
             all_results = {}
             for username in members:
-                pvc_results = ensure_user_notebook_pvc(username, projects)
+                try:
+                    user_uid = _get_user_uid(username)
+                except ApiException as e:
+                    if e.status == 404:
+                        logger.warning(f"User CRD not found for {username}, skipping PVC provisioning")
+                        all_results[username] = {}
+                        continue
+                    raise
+                pvc_results = ensure_user_notebook_pvc(username, projects, user_uid)
                 all_results[username] = pvc_results
 
             # Summarise results

--- a/src/cr8tor/handlers/vdi_handler.py
+++ b/src/cr8tor/handlers/vdi_handler.py
@@ -1,6 +1,7 @@
 """VDI Handler for managing VDIInstance custom resources using Kopf."""
 
 import logging
+import os
 
 import kopf
 import kubernetes
@@ -15,6 +16,7 @@ from cr8tor.services.storage_manager import (
     ensure_workspace_pvc,
     delete_workspace_pvc,
     get_pvc_name,
+    get_project_uid,
 )
 
 
@@ -175,7 +177,18 @@ def create_vdi(spec, name, namespace, patch, body, **kwargs):
     storage_size, storage_class, persist, pvc_enabled = resolve_vdi_storage_config(spec, project)
 
     if pvc_enabled:
-        pvc_name = get_pvc_name("vdi", user, project)
+        identity_namespace = os.environ.get("IDENTITY_NAMESPACE", "keycloak")
+        custom_api = kubernetes.client.CustomObjectsApi()
+        user_obj = custom_api.get_namespaced_custom_object(
+            group="identity.karectl.io",
+            version="v1alpha1",
+            plural="users",
+            namespace=identity_namespace,
+            name=user,
+        )
+        user_uid = user_obj["metadata"]["uid"]
+        project_uid = get_project_uid(project)
+        pvc_name = get_pvc_name("vdi", user_uid, project_uid)
         print(f"Storage enabled: size={storage_size}, class={storage_class}, persist={persist}", flush=True)
 
         # Create PVC for persistent home directory

--- a/src/cr8tor/services/storage_manager.py
+++ b/src/cr8tor/services/storage_manager.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import re
 
 import kubernetes
 from kubernetes.client.exceptions import ApiException
@@ -11,17 +10,15 @@ from kubernetes.client.exceptions import ApiException
 logger = logging.getLogger(__name__)
 
 
-def get_pvc_name(workspace_type, username, project):
+def get_pvc_name(workspace_type, user_uid, project_uid):
     """Generate PVC name for a workspace.
 
     Args:
         workspace_type: Type of workspace ('vdi' or 'notebook')
-        username: Username
-        project: Project name
+        user_uid: k8s metadata.uid of the User CRD
+        project_uid: k8s metadata.uid of the Project CRD
     """
-    safe_user = re.sub(r"[^a-z0-9-]", "", username.lower())
-    safe_project = re.sub(r"[^a-z0-9-]", "", project.lower())
-    return f"{workspace_type}-{safe_user}-{safe_project}"
+    return f"{workspace_type}-{user_uid}-{project_uid}"
 
 
 def get_bytes(size_str):
@@ -106,6 +103,24 @@ def _get_project_spec(project_name):
             logger.warning(f"Project {project_name} not found")
             return {}
         raise
+
+
+def get_project_uid(project_name):
+    """ Get the k8s metadata.uid of a Project CRD.
+
+    Args:
+        project_name: project name (CRD resource name)
+    """
+    api = kubernetes.client.CustomObjectsApi()
+    identity_namespace = os.environ.get("IDENTITY_NAMESPACE", "keycloak")
+    project = api.get_namespaced_custom_object(
+        group="research.karectl.io",
+        version="v1alpha1",
+        plural="projects",
+        namespace=identity_namespace,
+        name=project_name,
+    )
+    return project["metadata"]["uid"]
 
 
 def _get_resource_entry(spec, resource_type):


### PR DESCRIPTION
- Replaced normalised name PVC naming with k8s crd uid
- Updated ensure_user_notebook_pvc to use user_uid and looks up project_uid per iteration
- Updated every logic to label-based PVC lookup

Related change in karectl
https://github.com/karectl/karectl/pull/242