### PR TITLE
remove R Statistical Computing profile

### DIFF
--- a/src/cr8tor/cli/deploy.py
+++ b/src/cr8tor/cli/deploy.py
@@ -146,17 +146,7 @@ def create_deployment(
                             ],
                         ),
                     ),
-                    ProfileConfig(
-                        display_name="R Statistical Computing",
-                        slug="r-stats",
-                        description="R environment for statistical analysis",
-                        kubespawner_override=KubespawnerOverride(
-                            image="rocker/tidyverse:latest",
-                            env=[
-                                EnvironmentVariable(name="DISABLE_AUTH", value="true"),
-                            ],
-                        ),
-                    ),
+
                 ],
             ),
             # VDI (guacamole) is a capability so no need to control per user level


### PR DESCRIPTION
- Removed the hardcoded R Computing profile (rocker/tidyverse:latest) from the jupyterhub profiles
- New projects deployed via cr8tor deploy will no longer include this profile.
