### PR TITLE
bug: Allow project namespaces to communicate with datashield

### DIFF
--- a/examples/linkml-project-2/resources/deployment/cr8-deployment.yaml
+++ b/examples/linkml-project-2/resources/deployment/cr8-deployment.yaml
@@ -13,3 +13,7 @@ resources:
     url: https://auth.example.org
     enabled: true
     realm: dev-tre
+
+  - name: opal
+    resource_type: DataSHIELD
+    enabled: true

--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -481,10 +481,19 @@ def project_create_update(body, spec, meta, patch, **kwargs):
             message=f"Failed to ensure RoleBinding for {project_name}: {e}",
         )
 
-    # CiliumNetworkPolicy in the project namespace
+    # CiliumNetworkPolicy in the project namespace.
+    # Datashield namespace access is only granted to projects which are enabled
+    datashield_enabled = any(
+        r.get("resource_type") == "DataSHIELD" and r.get("enabled", True)
+        for r in resources
+    )
     try:
         ns_name = get_proj_namespace(project_name)
-        policy_result = create_project_network_policy(project_name, namespace=ns_name)
+        policy_result = create_project_network_policy(
+            project_name,
+            namespace=ns_name,
+            datashield_enabled=datashield_enabled,
+        )
         kopf.info(
             meta,
             reason="NetworkPolicyCreated",

--- a/src/cr8tor/services/network_policy_manager.py
+++ b/src/cr8tor/services/network_policy_manager.py
@@ -90,7 +90,7 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: keycloak
-    # Allow from datashield namespace (opal/datashield)
+    # Allow to datashield namespace (opal/datashield)
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: datashield

--- a/src/cr8tor/services/network_policy_manager.py
+++ b/src/cr8tor/services/network_policy_manager.py
@@ -2,7 +2,7 @@
 
 Plan for custom CiliumNetworkPolicy per project namespace:
 - Allows all intra-namespace traffic (same project)
-- Allows traffic from/to infrastructure namespaces (jupyterhub, backend, cr8tor, keycloak)
+- Allows traffic from/to infrastructure namespaces (jupyterhub, backend, cr8tor, keycloak, datashield)
 - Allows DNS resolution via kube-dns
 - Allows external/internet access
 - Cross-project isolation so different namespaces can't communicate
@@ -54,6 +54,10 @@ spec:
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: keycloak
+    # Allow from datashield namespace (opal/datashield)
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: datashield
 
   egress:
     # Allow all intra-namespace traffic
@@ -86,6 +90,10 @@ spec:
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: keycloak
+    # Allow from datashield namespace (opal/datashield)
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: datashield
     # Allow external/internet access
     - toEntities:
         - world

--- a/src/cr8tor/services/network_policy_manager.py
+++ b/src/cr8tor/services/network_policy_manager.py
@@ -2,10 +2,11 @@
 
 Plan for custom CiliumNetworkPolicy per project namespace:
 - Allows all intra-namespace traffic (same project)
-- Allows traffic from/to infrastructure namespaces (jupyterhub, backend, cr8tor, keycloak, datashield)
+- Allows traffic from/to infrastructure namespaces (jupyterhub, backend, cr8tor, keycloak)
 - Allows DNS resolution via kube-dns
 - Allows external/internet access
 - Cross-project isolation so different namespaces can't communicate
+- Datashield namespace access granted only to projects with a Datashield resource
 """
 
 import logging
@@ -53,11 +54,7 @@ spec:
     # Allow from keycloak namespace
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: keycloak
-    # Allow from datashield namespace (opal/datashield)
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: datashield
+            k8s:io.kubernetes.pod.namespace: keycloak{datashield_ingress}
 
   egress:
     # Allow all intra-namespace traffic
@@ -89,23 +86,34 @@ spec:
     # Allow to keycloak namespace (authentication)
     - toEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: keycloak
-    # Allow to datashield namespace (opal/datashield)
-    - toEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: datashield
+            k8s:io.kubernetes.pod.namespace: keycloak{datashield_egress}
     # Allow external/internet access
     - toEntities:
         - world
 """
 
+# Optional rule appended to ingress/egress only for federation projects.
+_DATASHIELD_INGRESS = """
+    # Allow from datashield namespace (opal/datashield)
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: datashield"""
 
-def create_project_network_policy(project_name, namespace):
+_DATASHIELD_EGRESS = """
+    # Allow to datashield namespace (opal/datashield)
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: datashield"""
+
+
+def create_project_network_policy(project_name, namespace, datashield_enabled=False):
     """ Create a CiliumNetworkPolicy in the project namespace.
 
     Args:
         project_name: Name of the project
         namespace: Project namespace
+        datashield_enabled: When True, adds ingress/egress rules for the
+            datashield namespace.
 
     Returns:
         dict with status of the operation
@@ -115,6 +123,8 @@ def create_project_network_policy(project_name, namespace):
     policy_yaml = NAMESPACE_NETWORK_POLICY_TEMPLATE.format(
         project_name=project_name,
         namespace=namespace,
+        datashield_ingress=_DATASHIELD_INGRESS if datashield_enabled else "",
+        datashield_egress=_DATASHIELD_EGRESS if datashield_enabled else "",
     )
     policy_body = yaml.safe_load(policy_yaml)
 
@@ -135,7 +145,7 @@ def create_project_network_policy(project_name, namespace):
             name=policy_name,
             body=policy_body,
         )
-        logger.info(f"Updated CiliumNetworkPolicy in {namespace}")
+        logger.info(f"Updated CiliumNetworkPolicy in {namespace} (datashield_enabled={datashield_enabled})")
         return {"status": "updated", "name": policy_name, "namespace": namespace}
 
     except ApiException as e:
@@ -147,7 +157,7 @@ def create_project_network_policy(project_name, namespace):
                 plural="ciliumnetworkpolicies",
                 body=policy_body,
             )
-            logger.info(f"Created CiliumNetworkPolicy in {namespace}")
+            logger.info(f"Created CiliumNetworkPolicy in {namespace} (datashield_enabled={datashield_enabled})")
             return {"status": "created", "name": policy_name, "namespace": namespace}
         else:
             logger.error(f"Failed to create/update CiliumNetworkPolicy in {namespace}: {e}")


### PR DESCRIPTION
- Added datashield namespace to the project-isolation CiliumNetworkPolicy template
    -  Without this, project namespace pods were blocked from reaching opal