### PR TITLE
fix for self-heal accounts without credentials on sync

### DIFF
--- a/src/cr8tor/services/user_manager.py
+++ b/src/cr8tor/services/user_manager.py
@@ -1,4 +1,4 @@
-from keycloak.exceptions import KeycloakGetError, KeycloakPutError, KeycloakDeleteError
+from keycloak.exceptions import KeycloakGetError, KeycloakDeleteError
 from .client import get_client
 from .utils import generate_temp_password, write_passwords
 
@@ -11,8 +11,13 @@ def sync_keycloak_user(username, spec):
     password = spec.get("password")
     first_name = spec.get("given_name", "")
     last_name = spec.get("family_name", "")
-    user_created = False
     temp_password = None
+
+    attributes = {}
+    for key in ("expiry_date", "start_date", "affiliation"):
+        value = spec.get(key)
+        if value:
+            attributes[key] = [str(value)]
 
     user_payload = {
         "username": username,
@@ -20,33 +25,22 @@ def sync_keycloak_user(username, spec):
         "enabled": enabled,
         "firstName": first_name,
         "lastName": last_name,
+        "attributes": attributes,
     }
 
-    # Try to get the user first
-    try:
-        user_id = keycloak_client.get_user_id(username)
-        try:
-            # Try updating the user
-            keycloak_client.update_user(user_id, user_payload)
-        except KeycloakPutError as err:
-            if "User not found" in str(err):
-                print(f"[INFO] User {username} not found on update, creating instead.")
-                user_id = keycloak_client.create_user(user_payload)
-                user_created = True
-            else:
-                raise
-
-    except KeycloakGetError:
-        # If user does not exist, create them
-        print(f"[INFO] User {username} not found, creating.")
-        user_id = keycloak_client.create_user(user_payload)
-        user_created = True
-
-    # Always get the actual user_id (in case it was just created)
     user_id = keycloak_client.get_user_id(username)
 
-    # Set a temp password if the user was just created
-    if user_created:
+    if user_id is None:
+        print(f"[INFO] User {username} not found, creating.")
+        user_id = keycloak_client.create_user(user_payload)
+        needs_password = True
+    else:
+        keycloak_client.update_user(user_id, user_payload)
+        needs_password = len(keycloak_client.get_credentials(user_id)) == 0
+        if needs_password:
+            print(f"[INFO] User {username} exists with no credentials, setting password.")
+
+    if needs_password:
         if password:
             keycloak_client.set_user_password(user_id, password, temporary=True)
             temp_password = password


### PR DESCRIPTION
- Fixed a bug in sync_keycloak_user where users could end up in keycloak without any credentials after a realm rebuild with the new changes
- Updated the option to pass end_date from the cr8tor to the keycloak