### PR TITLE
fix: increase default namespace ResourceQuota

### DIFF
--- a/src/cr8tor/services/namespace_manager.py
+++ b/src/cr8tor/services/namespace_manager.py
@@ -89,10 +89,10 @@ def ensure_resource_quota(project_name, quota_config=None):
         quota_config = {}
 
     hard = {
-        "requests.cpu": quota_config.get("requests_cpu", "32"),
-        "requests.memory": quota_config.get("requests_memory", "64Gi"),
-        "limits.cpu": quota_config.get("limits_cpu", "64"),
-        "limits.memory": quota_config.get("limits_memory", "128Gi"),
+        "requests.cpu": quota_config.get("requests_cpu", "12"),
+        "requests.memory": quota_config.get("requests_memory", "24Gi"),
+        "limits.cpu": quota_config.get("limits_cpu", "48"),
+        "limits.memory": quota_config.get("limits_memory", "120Gi"),
         "pods": quota_config.get("pods", "80"),
         "services": quota_config.get("services", "30"),
         "persistentvolumeclaims": quota_config.get("persistentvolumeclaims", "80"),

--- a/src/cr8tor/services/namespace_manager.py
+++ b/src/cr8tor/services/namespace_manager.py
@@ -89,13 +89,13 @@ def ensure_resource_quota(project_name, quota_config=None):
         quota_config = {}
 
     hard = {
-        "requests.cpu": quota_config.get("requests_cpu", "4"),
-        "requests.memory": quota_config.get("requests_memory", "8Gi"),
-        "limits.cpu": quota_config.get("limits_cpu", "8"),
-        "limits.memory": quota_config.get("limits_memory", "16Gi"),
-        "pods": quota_config.get("pods", "20"),
-        "services": quota_config.get("services", "10"),
-        "persistentvolumeclaims": quota_config.get("persistentvolumeclaims", "10"),
+        "requests.cpu": quota_config.get("requests_cpu", "32"),
+        "requests.memory": quota_config.get("requests_memory", "64Gi"),
+        "limits.cpu": quota_config.get("limits_cpu", "64"),
+        "limits.memory": quota_config.get("limits_memory", "128Gi"),
+        "pods": quota_config.get("pods", "80"),
+        "services": quota_config.get("services", "30"),
+        "persistentvolumeclaims": quota_config.get("persistentvolumeclaims", "80"),
     }
 
     # Add storage quota if specified


### PR DESCRIPTION
- `limits.memory` raised to 120Gi
-  `requests.memory` raised to 24Gi
-  `limits.cpu` raised to 48
-  `requests.cpu` raised to 12
-  `pods` raised to 80
-  `persistentvolumeclaims` raised to 80
-  `services` raised to 30
