### PR TITLE
feat: enforce password reset on first login for new and existing users

### DIFF
--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -236,13 +236,19 @@ def cleanup_user_notebook_pvcs(username, projects):
 @kopf.on.create("identity.karectl.io", "v1alpha1", "user")
 @kopf.on.update("identity.karectl.io", "v1alpha1", "user")
 @kopf.on.resume("identity.karectl.io", "v1alpha1", "user")
-def user_create_update(body, spec, meta, status, patch, **kwargs):
+def user_create_update(body, spec, meta, status, patch, diff, **kwargs):
     """ Operator function for creating and updating users.
         Provision notebook PVCs for the projects the user has access to.
     """
     username = spec["username"]
     ensure_realm_exists()
-    result = sync_keycloak_user(username, spec)
+
+    # Force a new temporary password when the spec password field is explicitly added or changed.
+    password_changed = any(
+        field == ("spec", "password") and op in ("add", "change")
+        for op, field, _, _ in (diff or [])
+    )
+    result = sync_keycloak_user(username, spec, force_password_reset=password_changed)
 
     if result and "password" in result:
         patch.status["initialPassword"] = result["password"]

--- a/src/cr8tor/services/client.py
+++ b/src/cr8tor/services/client.py
@@ -46,6 +46,9 @@ def ensure_realm_exists(realm_name=None, display_name=None):
         "verifyEmail": False,
         "requiredCredentials": ["password"],
         "defaultRoles": ["offline_access", "uma_authorization", "user"],
+        "requiredActions": [
+            {"alias": "UPDATE_PASSWORD", "providerId": "UPDATE_PASSWORD", "enabled": True, "defaultAction": False, "priority": 30, "config": {}},
+        ],
     }
     admin_client.create_realm(payload=payload)
     print(f"[Keycloak] Realm '{realm_name}' created.")

--- a/src/cr8tor/services/user_manager.py
+++ b/src/cr8tor/services/user_manager.py
@@ -3,7 +3,7 @@ from .client import get_client
 from .utils import generate_temp_password, write_passwords
 
 
-def sync_keycloak_user(username, spec):
+def sync_keycloak_user(username, spec, force_password_reset=False):
     """Sync a user to Keycloak."""
     keycloak_client = get_client()
     email = spec.get("email")
@@ -26,8 +26,10 @@ def sync_keycloak_user(username, spec):
     try:
         user_id = keycloak_client.get_user_id(username)
         try:
-            # Try updating the user
-            keycloak_client.update_user(user_id, user_payload)
+            # Preserve existing requiredActions
+            existing = keycloak_client.get_user(user_id)
+            payload = {**user_payload, "requiredActions": existing.get("requiredActions", [])}
+            keycloak_client.update_user(user_id, payload)
         except KeycloakPutError as err:
             if "User not found" in str(err):
                 print(f"[INFO] User {username} not found on update, creating instead.")
@@ -46,7 +48,7 @@ def sync_keycloak_user(username, spec):
     user_id = keycloak_client.get_user_id(username)
 
     # Set a temp password if the user was just created
-    if user_created:
+    if user_created or force_password_reset:
         if password:
             keycloak_client.set_user_password(user_id, password, temporary=True)
             temp_password = password


### PR DESCRIPTION
- Updates initial user password as temporary=True in Keycloak so users are forced to reset on first login
- Registers UPDATE_PASSWORD as a required action in the Keycloak realm

**Deployment Note**
This was tagged from this branch and deployed before for validation prior to merge. This PR brings the changes into main.
