### PR TITLE
feat: support per-fqdn multi-port egress rules in network policy

### DIFF
--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -492,7 +492,12 @@ def project_create_update(body, spec, meta, patch, **kwargs):
     # CiliumNetworkPolicy in the project namespace
     try:
         ns_name = get_proj_namespace(project_name)
-        policy_result = create_project_network_policy(project_name, namespace=ns_name)
+        approved_egress_rules = spec.get("approved_egress_rules") or []
+        policy_result = create_project_network_policy(
+            project_name,
+            namespace=ns_name,
+            approved_egress_rules=approved_egress_rules
+        )
         kopf.info(
             meta,
             reason="NetworkPolicyCreated",

--- a/src/cr8tor/services/network_policy_manager.py
+++ b/src/cr8tor/services/network_policy_manager.py
@@ -88,12 +88,13 @@ spec:
 """
 
 
-def create_project_network_policy(project_name, namespace):
+def create_project_network_policy(project_name, namespace, approved_egress_rules=None):
     """ Create a CiliumNetworkPolicy in the project namespace.
 
     Args:
         project_name: Name of the project
         namespace: Project namespace
+        approved_egress_rules: Optional list with fqdn and optional ports
 
     Returns:
         dict with status of the operation
@@ -105,6 +106,13 @@ def create_project_network_policy(project_name, namespace):
         namespace=namespace,
     )
     policy_body = yaml.safe_load(policy_yaml)
+
+    for rule in (approved_egress_rules or []):
+        ports = rule.get("ports") or [443]
+        policy_body["spec"]["egress"].append({
+            "toFQDNs": [{"matchName": rule["fqdn"]}],
+            "toPorts": [{"ports": [{"port": str(port), "protocol": "TCP"} for port in ports]}],
+        })
 
     try:
         existing = api.get_namespaced_custom_object(

--- a/src/cr8tor/services/network_policy_manager.py
+++ b/src/cr8tor/services/network_policy_manager.py
@@ -66,9 +66,10 @@ spec:
       toPorts:
         - ports:
             - port: "53"
-              protocol: UDP
-            - port: "53"
-              protocol: TCP
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
     # Allow to jupyterhub namespace (hub callbacks, proxy)
     - toEndpoints:
         - matchLabels:
@@ -106,6 +107,19 @@ def create_project_network_policy(project_name, namespace, approved_egress_rules
         namespace=namespace,
     )
     policy_body = yaml.safe_load(policy_yaml)
+
+    if approved_egress_rules:
+        # Restrict DNS proxy to cluster-internal names and approved FQDNs only.
+        dns_matches = [
+            {"matchPattern": "*.cluster.local"},
+            {"matchPattern": "*.internal"},
+        ]
+        dns_matches.extend({"matchName": rule["fqdn"]} for rule in approved_egress_rules)
+        for egress_rule in policy_body["spec"]["egress"]:
+            for ep in egress_rule.get("toEndpoints", []):
+                if ep.get("matchLabels", {}).get("k8s-app") == "kube-dns":
+                    egress_rule["toPorts"][0]["rules"]["dns"] = dns_matches
+                    break
 
     for rule in (approved_egress_rules or []):
         ports = rule.get("ports") or [443]


### PR DESCRIPTION
- Updated to generate one cilium egress entry per rule with all specified TCP ports
- Identity_handler gets the approved_egress_rules from the project crd spec and passes it through

Notes
- Each rule specifies fqdn and ports (optional, defaults to [443])

