### PR TITLE
fix(network-policy): Add direct gitea egress path for project

### DIFF
--- a/src/cr8tor/handlers/identity_handler.py
+++ b/src/cr8tor/handlers/identity_handler.py
@@ -493,10 +493,14 @@ def project_create_update(body, spec, meta, patch, **kwargs):
     try:
         ns_name = get_proj_namespace(project_name)
         approved_egress_rules = spec.get("approved_egress_rules") or []
+        gitea_enabled = any(
+            r.get("name") == "gitea" and r.get("enabled") for r in resources
+        )
         policy_result = create_project_network_policy(
             project_name,
             namespace=ns_name,
-            approved_egress_rules=approved_egress_rules
+            approved_egress_rules=approved_egress_rules,
+            gitea_enabled=gitea_enabled,
         )
         kopf.info(
             meta,

--- a/src/cr8tor/services/network_policy_manager.py
+++ b/src/cr8tor/services/network_policy_manager.py
@@ -89,13 +89,14 @@ spec:
 """
 
 
-def create_project_network_policy(project_name, namespace, approved_egress_rules=None):
+def create_project_network_policy(project_name, namespace, approved_egress_rules=None, gitea_enabled=False):
     """ Create a CiliumNetworkPolicy in the project namespace.
 
     Args:
         project_name: Name of the project
         namespace: Project namespace
         approved_egress_rules: Optional list with fqdn and optional ports
+        gitea_enabled: Whether the project has the gitea resource enabled
 
     Returns:
         dict with status of the operation
@@ -126,6 +127,17 @@ def create_project_network_policy(project_name, namespace, approved_egress_rules
         policy_body["spec"]["egress"].append({
             "toFQDNs": [{"matchName": rule["fqdn"]}],
             "toPorts": [{"ports": [{"port": str(port), "protocol": "TCP"} for port in ports]}],
+        })
+
+    if gitea_enabled:
+        policy_body["spec"]["egress"].append({
+            "toEndpoints": [{
+                "matchLabels": {
+                    "app.kubernetes.io/name": "gitea",
+                    "k8s:io.kubernetes.pod.namespace": "gitea",
+                }
+            }],
+            "toPorts": [{"ports": [{"port": "3000", "protocol": "TCP"}]}],
         })
 
     try:


### PR DESCRIPTION
- Added a direct `toEndpoints` rule to the gitea pod to enable the gitea access from project VDI/notebook pods
